### PR TITLE
Add inertial showcase and Level-1 control demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Generalized Adaptive Systems Demo
+
+This repository contains a demonstrative implementation of the Level‑0 primitives ⟨D, R, T, M⟩ and the Level‑1 differential operators described in *Foundational Principles for Generalized Adaptive Systems*. The goal is to provide a concrete, inspectable simulation that shows how the primitives cooperate to drive Lyapunov drift and how the Level‑1 refinements accelerate adaptation.
+
+The repository now includes two vivid demonstrations:
+
+1. **Scalar Lyapunov descent.** A one‑dimensional controlled process with a quadratic objective where Level‑0 and Level‑1 agents can be compared head‑to‑head using the canonical primitives.
+2. **Inertial stabilization.** A damped mass‑spring plant with inertia. The Level‑0 agent only observes position, while the Level‑1 agent sees the full state, leverages relation derivatives, and annihilates overshoot to settle dramatically faster.
+
+## Repository layout
+
+```
+README.md                # This file.
+gas_demo/                # GAS primitives, agents, and simulation utilities.
+    __init__.py
+    objectives.py
+    primitives.py
+    simulation.py
+    demo.py              # Legacy scalar comparison.
+    inertial.py          # High-impact inertial showcase primitives.
+    showcase.py          # Combined "wow" demo runner.
+    visualization.py     # Textual visualization helpers.
+tests/
+    test_adaptivity.py   # Ensures both agents reduce the Lyapunov objective.
+```
+
+## Running the demo
+
+```bash
+python -m gas_demo.showcase
+```
+
+This command first runs the scalar Lyapunov descent demo and then launches the inertial showcase. Expect to see the Level‑1 controller slash overshoot and settle in a fraction of the time while still respecting the Lyapunov drift guarantees.
+
+The legacy scalar comparison is still available if you prefer the minimal setup:
+
+```bash
+python -m gas_demo.demo
+```
+
+## Running the tests
+
+```bash
+python -m unittest discover -s tests
+```
+
+The tests verify that both agents decrease the Lyapunov functional and that the Level‑1 agent achieves strictly better convergence after the same number of steps.
+
+## Extending the demo
+
+The code is intentionally modular. You can experiment with alternative objectives, relation kernels, and memory dynamics by composing new primitives:
+
+- Implement a new `Distinction` to extract richer features (e.g., higher-order inertial moments).
+- Swap the `Relation` for a nonlinear or data‑driven kernel.
+- Replace the `Transformation` with a reinforcement‑learning policy.
+- Encode advanced filtering or estimator logic inside the `Memory`.
+
+Each component remains measurable and composable, preserving the Level‑0 guarantees while enabling exploration of higher‑level operators.

--- a/gas_demo/__init__.py
+++ b/gas_demo/__init__.py
@@ -1,0 +1,11 @@
+"""Generalized Adaptive Systems demo package."""
+
+__all__ = [
+    "demo",
+    "objectives",
+    "primitives",
+    "simulation",
+    "visualization",
+    "inertial",
+    "showcase",
+]

--- a/gas_demo/demo.py
+++ b/gas_demo/demo.py
@@ -1,0 +1,82 @@
+"""Command-line demo for the GAS primitives and derivatives."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Sequence
+
+from .objectives import QuadraticObjective
+from .primitives import (
+    DifferentialDistinction,
+    DifferentialMemory,
+    DifferentialTransformation,
+    GradientDescentTransformation,
+    IdentityDistinction,
+    LinearRelation,
+    RobbinsMonroMemory,
+)
+from .simulation import AgentComponents, run_agent
+from .visualization import describe_trajectory, format_summary_table
+
+
+@dataclass(frozen=True)
+class DemoConfig:
+    """Configuration for the closed-loop simulation."""
+
+    horizon: int = 60
+    initial_state: float = 3.0
+    seed: int = 7
+
+
+def build_agents(relation: LinearRelation) -> Sequence[AgentComponents]:
+    del relation  # Relation-specific tuning can be added later.
+    level0 = AgentComponents(
+        name="Level-0 (Robbins-Monro)",
+        distinction=IdentityDistinction(),
+        transformation=GradientDescentTransformation(base_step=0.7),
+        memory=RobbinsMonroMemory(beta=0.15),
+    )
+    level1 = AgentComponents(
+        name="Level-1 (Differential)",
+        distinction=DifferentialDistinction(decay=0.3),
+        transformation=DifferentialTransformation(base_step=0.9, damping=0.3),
+        memory=DifferentialMemory(beta=0.15, momentum=0.5),
+    )
+    return (level0, level1)
+
+
+def run_demo(config: DemoConfig) -> None:
+    relation = LinearRelation(dt=0.15, relaxation=0.35, noise_std=0.01)
+    objective = QuadraticObjective(target=0.0)
+    agents = build_agents(relation)
+    trajectories = [
+        run_agent(
+            components=agent,
+            relation=relation,
+            objective=objective,
+            initial_state=config.initial_state,
+            horizon=config.horizon,
+            seed=config.seed,
+        )
+        for agent in agents
+    ]
+    print("Generalized Adaptive Systems Demo")
+    print("=================================")
+    print(format_summary_table(trajectories))
+    print()
+    for traj in trajectories:
+        print(describe_trajectory(traj, prefix="- "))
+
+
+def parse_args() -> DemoConfig:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--horizon", type=int, default=60, help="number of time steps to simulate")
+    parser.add_argument("--initial-state", type=float, default=3.0, help="initial state u_0")
+    parser.add_argument("--seed", type=int, default=7, help="random seed for the environment noise")
+    args = parser.parse_args()
+    return DemoConfig(horizon=args.horizon, initial_state=args.initial_state, seed=args.seed)
+
+
+if __name__ == "__main__":
+    run_demo(parse_args())

--- a/gas_demo/inertial.py
+++ b/gas_demo/inertial.py
@@ -1,0 +1,359 @@
+"""High-impact inertial control showcase for GAS primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+import random
+
+from .objectives import Objective
+from .primitives import (
+    Distinction,
+    Memory,
+    MemoryState,
+    Relation,
+    Transformation,
+    simulate_step,
+)
+from .simulation import AgentComponents, Trajectory, TrajectoryStep
+
+
+# ---------------------------------------------------------------------------
+# State and relation definitions
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InertialState:
+    """Second-order plant state with position and velocity."""
+
+    position: float
+    velocity: float
+
+
+@dataclass(frozen=True)
+class InertialObservation:
+    """Observation exposing both position and velocity."""
+
+    position: float
+    velocity: float
+
+
+@dataclass
+class InertialRelation(Relation):
+    """Discrete-time damped mass-spring system."""
+
+    dt: float = 0.08
+    damping: float = 0.35
+    stiffness: float = 1.6
+    control_gain: float = 1.0
+    noise_std: float = 0.02
+
+    def expected(self, state: InertialState, action: float) -> InertialState:
+        accel = (
+            -self.stiffness * state.position
+            - self.damping * state.velocity
+            + self.control_gain * action
+        )
+        next_velocity = state.velocity + self.dt * accel
+        next_position = state.position + self.dt * next_velocity
+        return InertialState(position=next_position, velocity=next_velocity)
+
+    def sample(self, state: InertialState, action: float, rng: random.Random) -> InertialState:
+        deterministic = self.expected(state, action)
+        if self.noise_std <= 0:
+            return deterministic
+        noise = rng.gauss(0.0, self.noise_std)
+        return InertialState(
+            position=deterministic.position + self.dt * noise,
+            velocity=deterministic.velocity + noise,
+        )
+
+    def jacobian_action(self, state: InertialState, action: float) -> float:
+        del state, action
+        return (self.dt ** 2) * self.control_gain
+
+
+# ---------------------------------------------------------------------------
+# Distinctions
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PositionOnlyDistinction:
+    """Expose only the position component (Level-0 view)."""
+
+    def observe(self, state: InertialState, memory_state: MemoryState) -> float:
+        del memory_state
+        return state.position
+
+
+@dataclass(frozen=True)
+class FullInertialDistinction:
+    """Expose both position and velocity (Level-1 view)."""
+
+    def observe(self, state: InertialState, memory_state: MemoryState) -> InertialObservation:
+        del memory_state
+        return InertialObservation(position=state.position, velocity=state.velocity)
+
+
+# ---------------------------------------------------------------------------
+# Objective tailored to inertial control
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InertialEnergyObjective(Objective):
+    """Lyapunov function combining position error and velocity energy."""
+
+    position_weight: float = 1.0
+    velocity_weight: float = 0.35
+
+    def value(self, state) -> float:
+        if isinstance(state, InertialState):
+            pos = state.position
+            vel = state.velocity
+        else:
+            pos = float(state)
+            vel = 0.0
+        return 0.5 * (self.position_weight * pos * pos + self.velocity_weight * vel * vel)
+
+    def gradient(self, state) -> float:
+        if isinstance(state, InertialState):
+            pos = state.position
+        else:
+            pos = float(state)
+        return self.position_weight * pos
+
+    def velocity_penalty(self, state: InertialState) -> float:
+        return self.velocity_weight * state.velocity
+
+
+# ---------------------------------------------------------------------------
+# Memory
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InertialMemory(Memory):
+    """Track kinetic energy and responsiveness statistics."""
+
+    beta: float = 0.1
+
+    def init_state(self) -> MemoryState:
+        return MemoryState()
+
+    def update(
+        self,
+        memory_state: MemoryState,
+        *,
+        observation: object,
+        action: float,
+        cost: float,
+        next_state: InertialState,
+        objective: Objective,
+    ) -> MemoryState:
+        return MemoryState(
+            step=memory_state.step + 1,
+            avg_cost=memory_state.avg_cost + self.beta * (cost - memory_state.avg_cost),
+            change_count=
+            memory_state.change_count
+            + (
+                1
+                if memory_state.prev_action is not None
+                and abs(memory_state.prev_action - action) > 1e-9
+                else 0
+            ),
+            prev_action=action,
+            prev_state=next_state,
+            velocity=getattr(next_state, "velocity", getattr(observation, "velocity", memory_state.velocity)),
+            ema_gradient=
+            (1 - self.beta) * memory_state.ema_gradient
+            + self.beta * objective.gradient(next_state),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Controllers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InertialGradientController(Transformation):
+    """Naive gradient descent that ignores inertia."""
+
+    base_step: float = 0.6
+
+    def act(
+        self,
+        observation: object,
+        memory_state: MemoryState,
+        objective: Objective,
+        relation: Relation,
+    ) -> float:
+        del relation
+        del memory_state
+        position = float(observation)
+        gradient = objective.gradient(position)
+        action = -self.base_step * gradient
+        return max(min(action, 4.0), -4.0)
+
+
+@dataclass
+class InertialLookaheadController(Transformation):
+    """Level-1 controller solving the inertial control law analytically."""
+
+    position_gain: float = 1.6
+    velocity_gain: float = 1.2
+    max_action: float = 6.0
+
+    def act(
+        self,
+        observation: object,
+        memory_state: MemoryState,
+        objective: Objective,
+        relation: Relation,
+    ) -> float:
+        if not isinstance(observation, InertialObservation):
+            raise TypeError("InertialLookaheadController expects InertialObservation")
+        if not isinstance(relation, InertialRelation):
+            raise TypeError("InertialLookaheadController requires InertialRelation")
+        del memory_state
+        pos = observation.position
+        vel = observation.velocity
+        target_velocity = -self.position_gain * pos - self.velocity_gain * vel
+        velocity_change = (target_velocity - vel) / relation.dt
+        required_accel = velocity_change + relation.stiffness * pos + relation.damping * vel
+        action = required_accel / relation.control_gain
+        if isinstance(objective, InertialEnergyObjective):
+            grad = objective.gradient(InertialState(position=pos, velocity=vel))
+            action -= 0.1 * grad
+        action = max(min(action, self.max_action), -self.max_action)
+        return action
+
+
+# ---------------------------------------------------------------------------
+# Rollout utilities dedicated to the inertial showcase
+# ---------------------------------------------------------------------------
+
+
+def run_inertial_agent(
+    *,
+    components: AgentComponents,
+    relation: InertialRelation,
+    objective: Objective,
+    initial_state: InertialState,
+    horizon: int,
+    seed: int = 0,
+) -> Trajectory:
+    rng = random.Random(seed)
+    state = initial_state
+    memory_state = components.memory.init_state()
+    steps: list[TrajectoryStep] = []
+    cumulative_cost = 0.0
+    for t in range(horizon):
+        next_state, memory_state, action, cost, _ = simulate_step(
+            state,
+            distinction=components.distinction,
+            relation=relation,
+            transformation=components.transformation,
+            memory=components.memory,
+            memory_state=memory_state,
+            objective=objective,
+            rng=rng,
+        )
+        cumulative_cost += cost
+        steps.append(
+            TrajectoryStep(
+                time=t,
+                state=state,
+                action=action,
+                cost=cost,
+                memory_state=memory_state,
+            )
+        )
+        state = next_state  # type: ignore[assignment]
+    final_cost = objective.value(state)
+    average_cost = cumulative_cost / horizon if horizon else 0.0
+    return Trajectory(
+        agent=components.name,
+        steps=steps,
+        final_state=state,
+        final_cost=final_cost,
+        average_cost=average_cost,
+        action_change_rate=memory_state.action_change_rate(),
+    )
+
+
+def overshoot(traj: Trajectory) -> float:
+    """Compute the maximum absolute position encountered."""
+
+    max_dev = 0.0
+    for step in traj.steps:
+        state = step.state
+        if isinstance(state, InertialState):
+            if step.time > 0:
+                max_dev = max(max_dev, abs(state.position))
+    final_state = traj.final_state
+    if isinstance(final_state, InertialState):
+        max_dev = max(max_dev, abs(final_state.position))
+    return max_dev
+
+
+def settling_time(traj: Trajectory, tolerance: float = 0.05) -> int:
+    """Return the first step index at which the position stays within tolerance."""
+
+    positions: list[Tuple[int, float]] = []
+    for step in traj.steps:
+        state = step.state
+        if isinstance(state, InertialState):
+            positions.append((step.time, abs(state.position)))
+    last_time = traj.steps[-1].time if traj.steps else 0
+    final = traj.final_state
+    if isinstance(final, InertialState):
+        positions.append((last_time + 1, abs(final.position)))
+    window = 5
+    for idx in range(len(positions)):
+        window_vals = [pos for _, pos in positions[idx : idx + window]]
+        if len(window_vals) < window:
+            break
+        if all(val <= tolerance for val in window_vals):
+            return positions[idx][0]
+    return last_time
+
+
+def energy_threshold_time(traj: Trajectory, fraction: float = 0.1) -> int:
+    """Return the first step index where cost <= fraction of the initial cost."""
+
+    if not traj.steps:
+        return 0
+    baseline = traj.steps[0].cost
+    target = baseline * fraction
+    for step in traj.steps:
+        if step.cost <= target:
+            return step.time
+    return traj.steps[-1].time
+
+
+def format_inertial_summary(trajectories: Iterable[Trajectory]) -> str:
+    """Produce a table with overshoot and settling-time comparisons."""
+
+    headers = ["Agent", "Final J", "Overshoot", "Settling", "10% energy"]
+    rows = [headers]
+    for traj in trajectories:
+        rows.append(
+            [
+                traj.agent,
+                f"{traj.final_cost:8.5f}",
+                f"{overshoot(traj):7.4f}",
+                f"{settling_time(traj):5d}",
+                f"{energy_threshold_time(traj):5d}",
+            ]
+        )
+    col_widths = [max(len(row[i]) for row in rows) for i in range(len(headers))]
+    formatted = []
+    for row in rows:
+        formatted.append(" | ".join(cell.ljust(col_widths[i]) for i, cell in enumerate(row)))
+    separator = "-+-".join("-" * width for width in col_widths)
+    return "\n".join([formatted[0], separator, *formatted[1:]])
+

--- a/gas_demo/objectives.py
+++ b/gas_demo/objectives.py
@@ -1,0 +1,30 @@
+"""Lyapunov-style objective functions for the GAS demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Any
+
+
+class Objective(Protocol):
+    """Protocol for Lyapunov-style objectives."""
+
+    def value(self, state: Any) -> float:
+        """Return :math:`J(u)` for the current state."""
+
+    def gradient(self, state: Any) -> float:
+        """Return :math:`\nabla J(u)` for the current state."""
+
+
+@dataclass(frozen=True)
+class QuadraticObjective:
+    r"""Quadratic Lyapunov functional :math:`J(u) = 0.5 (u - u_\star)^2`."""
+
+    target: float = 0.0
+
+    def value(self, state) -> float:
+        deviation = float(state) - self.target
+        return 0.5 * deviation * deviation
+
+    def gradient(self, state) -> float:
+        return float(state) - self.target

--- a/gas_demo/primitives.py
+++ b/gas_demo/primitives.py
@@ -1,0 +1,323 @@
+"""Core primitives and derivative operators for the GAS demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol, Any
+import math
+import random
+
+from .objectives import Objective
+
+
+# ---------------------------------------------------------------------------
+# Distinction primitives
+# ---------------------------------------------------------------------------
+
+
+class Distinction(Protocol):
+    """Extract observable structure from the underlying state."""
+
+    def observe(self, state: Any, memory_state: "MemoryState") -> object:
+        """Return a measurable observation derived from the current state."""
+
+
+@dataclass(frozen=True)
+class IdentityDistinction:
+    """Return the raw state as the only distinction."""
+
+    def observe(self, state: Any, memory_state: "MemoryState") -> float:
+        return state
+
+
+@dataclass(frozen=True)
+class DifferentialObservation:
+    """Distinction that includes a finite difference velocity estimate."""
+
+    state: float
+    velocity: float
+
+
+@dataclass(frozen=True)
+class DifferentialDistinction:
+    """Augment the raw state with a first-order velocity estimate."""
+
+    decay: float = 0.2
+
+    def observe(self, state: Any, memory_state: "MemoryState") -> DifferentialObservation:
+        if memory_state.prev_state is None:
+            velocity = 0.0
+        else:
+            try:
+                raw_velocity = state - memory_state.prev_state  # type: ignore[operator]
+            except TypeError:
+                raw_velocity = 0.0
+            velocity = (1 - self.decay) * memory_state.velocity + self.decay * float(raw_velocity)
+        return DifferentialObservation(state=state, velocity=velocity)
+
+
+# ---------------------------------------------------------------------------
+# Relation primitives
+# ---------------------------------------------------------------------------
+
+
+class Relation(Protocol):
+    """Map state/action pairs to distributions over next states."""
+
+    def sample(self, state: Any, action: float, rng: random.Random) -> Any:
+        """Sample the next state given the current state and action."""
+
+    def expected(self, state: Any, action: float) -> Any:
+        r"""Return :math:`\mathbb E[u_{t+1} \mid u_t = state, a_t = action]`."""
+
+    def jacobian_action(self, state: Any, action: float) -> float:
+        r"""Return :math:`\partial R / \partial a` evaluated at the given point."""
+
+
+@dataclass(frozen=True)
+class LinearRelation:
+    """Controlled linear dynamics with optional Gaussian noise."""
+
+    dt: float = 0.1
+    relaxation: float = 0.4
+    noise_std: float = 0.02
+
+    def sample(self, state: float, action: float, rng: random.Random) -> float:
+        mean = self.expected(state, action)
+        if self.noise_std <= 0:
+            return mean
+        return rng.gauss(mean, self.noise_std)
+
+    def expected(self, state: float, action: float) -> float:
+        drift = -self.relaxation * state + action
+        return state + self.dt * drift
+
+    def jacobian_action(self, state: float, action: float) -> float:
+        del state, action  # Unused; jacobian is constant for linear dynamics.
+        return self.dt
+
+
+# ---------------------------------------------------------------------------
+# Memory primitives
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MemoryState:
+    """Internal information state maintained by the agent."""
+
+    step: int = 0
+    avg_cost: float = 0.0
+    change_count: int = 0
+    prev_action: Optional[float] = None
+    prev_state: Optional[object] = None
+    velocity: float = 0.0
+    ema_gradient: float = 0.0
+
+    def action_change_rate(self) -> float:
+        if self.step == 0:
+            return 0.0
+        return self.change_count / self.step
+
+
+class Memory(Protocol):
+    """Protocol describing how memory is initialized and updated."""
+
+    def init_state(self) -> MemoryState:
+        ...
+
+    def update(
+        self,
+        memory_state: MemoryState,
+        *,
+        observation: object,
+        action: float,
+        cost: float,
+        next_state: Any,
+        objective: Objective,
+    ) -> MemoryState:
+        ...
+
+
+@dataclass
+class RobbinsMonroMemory:
+    """Track running statistics required by the Level-0 drift analysis."""
+
+    beta: float = 0.1
+
+    def init_state(self) -> MemoryState:
+        return MemoryState()
+
+    def update(
+        self,
+        memory_state: MemoryState,
+        *,
+        observation: object,
+        action: float,
+        cost: float,
+        next_state: Any,
+        objective: Objective,
+    ) -> MemoryState:
+        step = memory_state.step + 1
+        avg_cost = memory_state.avg_cost + self.beta * (cost - memory_state.avg_cost)
+        prev_action = memory_state.prev_action
+        change_count = memory_state.change_count
+        if prev_action is not None and abs(prev_action - action) > 1e-9:
+            change_count += 1
+        gradient = objective.gradient(next_state)
+        ema_gradient = (1 - self.beta) * memory_state.ema_gradient + self.beta * gradient
+        velocity = 0.0
+        if isinstance(observation, DifferentialObservation):
+            velocity = observation.velocity
+        elif hasattr(observation, "velocity"):
+            try:
+                velocity = float(getattr(observation, "velocity"))
+            except (TypeError, ValueError):
+                velocity = memory_state.velocity
+        return MemoryState(
+            step=step,
+            avg_cost=avg_cost,
+            change_count=change_count,
+            prev_action=action,
+            prev_state=next_state,
+            velocity=velocity,
+            ema_gradient=ema_gradient,
+        )
+
+
+@dataclass
+class DifferentialMemory(RobbinsMonroMemory):
+    """Memory that emphasises velocity estimates for Level-1 operators."""
+
+    momentum: float = 0.6
+
+    def update(
+        self,
+        memory_state: MemoryState,
+        *,
+        observation: object,
+        action: float,
+        cost: float,
+        next_state: float,
+        objective: Objective,
+    ) -> MemoryState:
+        base_state = super().update(
+            memory_state,
+            observation=observation,
+            action=action,
+            cost=cost,
+            next_state=next_state,
+            objective=objective,
+        )
+        velocity = base_state.velocity
+        if isinstance(observation, DifferentialObservation):
+            velocity = (1 - self.momentum) * observation.velocity + self.momentum * base_state.velocity
+        return MemoryState(
+            step=base_state.step,
+            avg_cost=base_state.avg_cost,
+            change_count=base_state.change_count,
+            prev_action=base_state.prev_action,
+            prev_state=base_state.prev_state,
+            velocity=velocity,
+            ema_gradient=base_state.ema_gradient,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Transformation primitives
+# ---------------------------------------------------------------------------
+
+
+class Transformation(Protocol):
+    """Map distinctions and memory to actions."""
+
+    def act(
+        self,
+        observation: object,
+        memory_state: MemoryState,
+        objective: Objective,
+        relation: Relation,
+    ) -> float:
+        ...
+
+
+@dataclass
+class GradientDescentTransformation:
+    """Level-0 policy implementing a Robbins–Monro step schedule."""
+
+    base_step: float = 0.6
+
+    def act(
+        self,
+        observation: object,
+        memory_state: MemoryState,
+        objective: Objective,
+        relation: Relation,
+    ) -> float:
+        del relation  # Not used in the Level-0 controller.
+        state = float(observation)
+        gradient = objective.gradient(state)
+        step_scale = self.base_step / math.sqrt(1 + memory_state.step)
+        return -step_scale * gradient
+
+
+@dataclass
+class DifferentialTransformation:
+    """Level-1 controller that leverages first-order dynamics of the relation."""
+
+    base_step: float = 0.6
+    damping: float = 0.2
+
+    def act(
+        self,
+        observation: object,
+        memory_state: MemoryState,
+        objective: Objective,
+        relation: Relation,
+    ) -> float:
+        if not isinstance(observation, DifferentialObservation):
+            raise TypeError("DifferentialTransformation expects DifferentialObservation")
+        state = observation.state
+        gradient = objective.gradient(state)
+        step_scale = self.base_step / math.sqrt(1 + memory_state.step)
+        desired_delta = -step_scale * gradient - self.damping * observation.velocity
+        baseline_next = relation.expected(state, 0.0)
+        derivative = relation.jacobian_action(state, 0.0)
+        if abs(derivative) < 1e-8:
+            return 0.0
+        target_next = state + desired_delta
+        action = (target_next - baseline_next) / derivative
+        return action
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def simulate_step(
+    state: float,
+    *,
+    distinction: Distinction,
+    relation: Relation,
+    transformation: Transformation,
+    memory: Memory,
+    memory_state: MemoryState,
+    objective: Objective,
+    rng: random.Random,
+) -> tuple[float, MemoryState, float, float, object]:
+    """Execute a single closed-loop step of the GAS process."""
+
+    observation = distinction.observe(state, memory_state)
+    action = transformation.act(observation, memory_state, objective, relation)
+    next_state = relation.sample(state, action, rng)
+    cost = objective.value(state)
+    next_memory = memory.update(
+        memory_state,
+        observation=observation,
+        action=action,
+        cost=cost,
+        next_state=next_state,
+        objective=objective,
+    )
+    return next_state, next_memory, action, cost, observation

--- a/gas_demo/showcase.py
+++ b/gas_demo/showcase.py
@@ -1,0 +1,138 @@
+"""High-energy showcase comparing Level-0 and Level-1 GAS controllers."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Sequence
+
+from .demo import build_agents as build_scalar_agents
+from .inertial import (
+    FullInertialDistinction,
+    InertialEnergyObjective,
+    InertialGradientController,
+    InertialLookaheadController,
+    InertialMemory,
+    InertialRelation,
+    InertialState,
+    PositionOnlyDistinction,
+    format_inertial_summary,
+    run_inertial_agent,
+)
+from .objectives import QuadraticObjective
+from .primitives import LinearRelation
+from .simulation import AgentComponents, run_agent
+from .visualization import describe_trajectory, format_summary_table
+
+
+@dataclass(frozen=True)
+class ShowcaseConfig:
+    """Configuration for both scalar and inertial demos."""
+
+    horizon: int = 80
+    initial_scalar_state: float = 3.0
+    initial_inertial_position: float = 2.5
+    initial_inertial_velocity: float = 0.0
+    seed: int = 11
+
+
+def run_scalar_demo(config: ShowcaseConfig) -> Sequence[str]:
+    relation = LinearRelation(dt=0.12, relaxation=0.3, noise_std=0.01)
+    objective = QuadraticObjective(target=0.0)
+    agents = build_scalar_agents(relation)
+    trajectories = [
+        run_agent(
+            components=agent,
+            relation=relation,
+            objective=objective,
+            initial_state=config.initial_scalar_state,
+            horizon=config.horizon,
+            seed=config.seed,
+        )
+        for agent in agents
+    ]
+    output = ["Scalar Lyapunov Descent", "-------------------------", format_summary_table(trajectories), ""]
+    output.extend(describe_trajectory(traj, prefix="  ") for traj in trajectories)
+    output.append("")
+    return output
+
+
+def build_inertial_agents() -> Sequence[AgentComponents]:
+    level0 = AgentComponents(
+        name="Level-0 (Position only)",
+        distinction=PositionOnlyDistinction(),
+        transformation=InertialGradientController(base_step=0.6),
+        memory=InertialMemory(beta=0.1),
+    )
+    level1 = AgentComponents(
+        name="Level-1 (Lookahead)",
+        distinction=FullInertialDistinction(),
+        transformation=InertialLookaheadController(position_gain=1.6, velocity_gain=1.2),
+        memory=InertialMemory(beta=0.1),
+    )
+    return (level0, level1)
+
+
+def run_inertial_demo(config: ShowcaseConfig) -> Sequence[str]:
+    relation = InertialRelation(dt=0.08, damping=0.32, stiffness=1.55, noise_std=0.015)
+    objective = InertialEnergyObjective(position_weight=1.0, velocity_weight=0.45)
+    agents = build_inertial_agents()
+    initial_state = InertialState(position=config.initial_inertial_position, velocity=config.initial_inertial_velocity)
+    trajectories = [
+        run_inertial_agent(
+            components=agent,
+            relation=relation,
+            objective=objective,
+            initial_state=initial_state,
+            horizon=config.horizon,
+            seed=config.seed,
+        )
+        for agent in agents
+    ]
+    header = ["Inertial Stabilization", "----------------------", format_inertial_summary(trajectories), ""]
+    details = [describe_trajectory(traj, prefix="  ") for traj in trajectories]
+    return [*header, *details]
+
+
+def parse_args() -> ShowcaseConfig:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--horizon", type=int, default=80, help="number of steps to simulate")
+    parser.add_argument("--seed", type=int, default=11, help="random seed for reproducibility")
+    parser.add_argument("--scalar-state", type=float, default=3.0, help="initial scalar state u_0")
+    parser.add_argument(
+        "--inertial-position",
+        type=float,
+        default=2.5,
+        help="initial position for the inertial plant",
+    )
+    parser.add_argument(
+        "--inertial-velocity",
+        type=float,
+        default=0.0,
+        help="initial velocity for the inertial plant",
+    )
+    args = parser.parse_args()
+    return ShowcaseConfig(
+        horizon=args.horizon,
+        seed=args.seed,
+        initial_scalar_state=args.scalar_state,
+        initial_inertial_position=args.inertial_position,
+        initial_inertial_velocity=args.inertial_velocity,
+    )
+
+
+def main() -> None:
+    config = parse_args()
+    sections = [
+        "Generalized Adaptive Systems Showcase",
+        "====================================",
+    ]
+    sections.extend(run_scalar_demo(config))
+    sections.append("")
+    sections.extend(run_inertial_demo(config))
+    print("\n".join(sections))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/gas_demo/simulation.py
+++ b/gas_demo/simulation.py
@@ -1,0 +1,103 @@
+"""Simulation utilities for composing GAS primitives into agents.""" 
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Any
+import random
+
+from .objectives import Objective
+from .primitives import (
+    Distinction,
+    Memory,
+    MemoryState,
+    Relation,
+    Transformation,
+    simulate_step,
+)
+
+
+@dataclass(frozen=True)
+class AgentComponents:
+    """Bundle of primitives that define a GAS agent."""
+
+    name: str
+    distinction: Distinction
+    transformation: Transformation
+    memory: Memory
+
+
+@dataclass(frozen=True)
+class TrajectoryStep:
+    """Recorded information for a single simulation step."""
+
+    time: int
+    state: object
+    action: float
+    cost: float
+    memory_state: MemoryState
+
+
+@dataclass(frozen=True)
+class Trajectory:
+    """Full rollout for an agent over a fixed horizon."""
+
+    agent: str
+    steps: List[TrajectoryStep]
+    final_state: object
+    final_cost: float
+    average_cost: float
+    action_change_rate: float
+
+    def costs(self) -> List[float]:
+        return [step.cost for step in self.steps]
+
+
+def run_agent(
+    *,
+    components: AgentComponents,
+    relation: Relation,
+    objective: Objective,
+    initial_state: float,
+    horizon: int,
+    seed: int = 0,
+) -> Trajectory:
+    """Simulate the closed-loop system for a given agent."""
+
+    rng = random.Random(seed)
+    state = initial_state
+    memory_state = components.memory.init_state()
+    steps: List[TrajectoryStep] = []
+    cumulative_cost = 0.0
+    for t in range(horizon):
+        next_state, memory_state, action, cost, _ = simulate_step(
+            state,
+            distinction=components.distinction,
+            relation=relation,
+            transformation=components.transformation,
+            memory=components.memory,
+            memory_state=memory_state,
+            objective=objective,
+            rng=rng,
+        )
+        cumulative_cost += cost
+        steps.append(
+            TrajectoryStep(
+                time=t,
+                state=state,
+                action=action,
+                cost=cost,
+                memory_state=memory_state,
+            )
+        )
+        state = next_state
+    final_cost = objective.value(state)
+    average_cost = cumulative_cost / horizon if horizon else 0.0
+    return Trajectory(
+        agent=components.name,
+        steps=steps,
+        final_state=state,
+        final_cost=final_cost,
+        average_cost=average_cost,
+        action_change_rate=memory_state.action_change_rate(),
+    )

--- a/gas_demo/visualization.py
+++ b/gas_demo/visualization.py
@@ -1,0 +1,45 @@
+"""Text-based visualization helpers for the GAS demo."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .simulation import Trajectory
+
+
+def format_summary_table(trajectories: Iterable[Trajectory]) -> str:
+    """Return a formatted table comparing multiple trajectories."""
+
+    headers = ["Agent", "Final J", "Avg J", "Action change rate"]
+    rows = [headers]
+    for traj in trajectories:
+        rows.append(
+            [
+                traj.agent,
+                f"{traj.final_cost:8.5f}",
+                f"{traj.average_cost:8.5f}",
+                f"{traj.action_change_rate:6.3f}",
+            ]
+        )
+    col_widths = [max(len(row[i]) for row in rows) for i in range(len(headers))]
+    formatted_rows = []
+    for row in rows:
+        formatted_rows.append(" | ".join(cell.ljust(col_widths[i]) for i, cell in enumerate(row)))
+    separator = "-+-".join("-" * width for width in col_widths)
+    return "\n".join([formatted_rows[0], separator, *formatted_rows[1:]])
+
+
+def describe_trajectory(traj: Trajectory, *, prefix: str = "") -> str:
+    """Return a line-by-line description of a trajectory's evolution."""
+
+    final_state = traj.final_state
+    if isinstance(final_state, float):
+        state_repr = f"{final_state:.4f}"
+    else:
+        state_repr = repr(final_state)
+    lines = [
+        f"{prefix}{traj.agent}: final state = {state_repr}, final cost = {traj.final_cost:.6f}",
+        f"{prefix}Action change rate: {traj.action_change_rate:.3f} (Inflection responsiveness)",
+        f"{prefix}First 5 costs: {', '.join(f'{c:.5f}' for c in traj.costs()[:5])}",
+    ]
+    return "\n".join(lines)

--- a/tests/test_adaptivity.py
+++ b/tests/test_adaptivity.py
@@ -1,0 +1,41 @@
+"""Regression tests for the GAS demo."""
+
+from __future__ import annotations
+
+import unittest
+
+from gas_demo.demo import DemoConfig, build_agents
+from gas_demo.objectives import QuadraticObjective
+from gas_demo.primitives import LinearRelation
+from gas_demo.simulation import run_agent
+
+
+class TestAdaptivity(unittest.TestCase):
+    """Ensure the demo agents satisfy the Level-0 drift guarantees."""
+
+    def test_level0_and_level1_reduce_cost(self) -> None:
+        relation = LinearRelation(dt=0.15, relaxation=0.35, noise_std=0.0)
+        objective = QuadraticObjective(target=0.0)
+        config = DemoConfig(horizon=50, initial_state=3.0, seed=5)
+        agents = build_agents(relation)
+        initial_cost = objective.value(config.initial_state)
+        trajectories = [
+            run_agent(
+                components=agent,
+                relation=relation,
+                objective=objective,
+                initial_state=config.initial_state,
+                horizon=config.horizon,
+                seed=config.seed,
+            )
+            for agent in agents
+        ]
+        for traj in trajectories:
+            with self.subTest(agent=traj.agent):
+                self.assertLess(traj.final_cost, initial_cost)
+        self.assertLess(trajectories[1].final_cost, trajectories[0].final_cost)
+        self.assertGreaterEqual(trajectories[1].action_change_rate, trajectories[0].action_change_rate)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_inertial.py
+++ b/tests/test_inertial.py
@@ -1,0 +1,57 @@
+"""Regression tests for the inertial GAS showcase."""
+
+from __future__ import annotations
+
+from gas_demo.inertial import (
+    FullInertialDistinction,
+    InertialEnergyObjective,
+    InertialGradientController,
+    InertialLookaheadController,
+    InertialMemory,
+    InertialRelation,
+    InertialState,
+    PositionOnlyDistinction,
+    energy_threshold_time,
+    overshoot,
+    run_inertial_agent,
+)
+from gas_demo.simulation import AgentComponents
+
+
+def test_inertial_level1_dominates_level0() -> None:
+    relation = InertialRelation(dt=0.08, damping=0.32, stiffness=1.55, noise_std=0.0)
+    objective = InertialEnergyObjective(position_weight=1.0, velocity_weight=0.45)
+    initial_state = InertialState(position=2.5, velocity=0.0)
+
+    level0 = AgentComponents(
+        name="Level-0",
+        distinction=PositionOnlyDistinction(),
+        transformation=InertialGradientController(base_step=0.6),
+        memory=InertialMemory(beta=0.1),
+    )
+    level1 = AgentComponents(
+        name="Level-1",
+        distinction=FullInertialDistinction(),
+        transformation=InertialLookaheadController(position_gain=1.6, velocity_gain=1.2),
+        memory=InertialMemory(beta=0.1),
+    )
+
+    traj0 = run_inertial_agent(
+        components=level0,
+        relation=relation,
+        objective=objective,
+        initial_state=initial_state,
+        horizon=120,
+        seed=0,
+    )
+    traj1 = run_inertial_agent(
+        components=level1,
+        relation=relation,
+        objective=objective,
+        initial_state=initial_state,
+        horizon=120,
+        seed=0,
+    )
+
+    assert traj1.final_cost < 0.15 * traj0.final_cost
+    assert energy_threshold_time(traj1) <= 0.5 * energy_threshold_time(traj0)


### PR DESCRIPTION
## Summary
- document the new scalar and inertial showcases and how to launch them from the CLI
- add an inertial control module with Level-0/Level-1 agents, analytic controllers, and rich rollout metrics
- introduce a combined showcase runner plus broaden primitives/simulation utilities to support vector-valued states and regression coverage for the inertial scenario

## Testing
- python -m gas_demo.showcase
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d14c2b41cc833086dfabe8bc356e36